### PR TITLE
BitcoinJKit set bitcoinj wallet to autosave

### DIFF
--- a/BitcoinJKit/java/bitcoinkit/src/main/java/com/hive/bitcoinkit/BitcoinManager.java
+++ b/BitcoinJKit/java/bitcoinkit/src/main/java/com/hive/bitcoinkit/BitcoinManager.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class BitcoinManager implements PeerEventListener {
 	private NetworkParameters networkParams;
@@ -250,6 +251,9 @@ public class BitcoinManager implements PeerEventListener {
             wallet.addKey(new ECKey());
             wallet.saveToFile(walletFile);
         }
+
+        //make wallet autosave
+        wallet.autosaveToFile(walletFile, 1, TimeUnit.SECONDS, null);
         
 
         // Fetch the first key in the wallet (should be the only key).


### PR DESCRIPTION
without wallet.autosave = true, wallets will not get stored after incoming tx, etc.
autosave is a standard behavior and should therefore be enabled.
